### PR TITLE
Correcting colorspace during frame extraction by updating utilities.py

### DIFF
--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -44,7 +44,7 @@ def detect_fps(target_path: str) -> float:
 
 def extract_frames(target_path: str) -> None:
     temp_directory_path = get_temp_directory_path(target_path)
-    run_ffmpeg(['-i', target_path, '-pix_fmt rgb24', '-sws_flags +accurate_rnd+full_chroma_int', '-colorspace 1', '-color_primaries 1', '-color_trc 1', os.path.join(temp_directory_path, '%04d.png')])
+    run_ffmpeg(['-i', target_path, '-pix_fmt', 'rgb24', '-sws_flags', '+accurate_rnd+full_chroma_int', '-colorspace', '1', '-color_primaries', '1', '-color_trc', '1', os.path.join(temp_directory_path, '%04d.png')])
 
 
 def create_video(target_path: str, fps: float = 30.0) -> None:


### PR DESCRIPTION
Updated the extraction process with the ffmpeg command that corrects the colorspace while extracting to png, and corrected the ffmpeg command, adding

'-pix_fmt', 'rgb24', '-sws_flags', '+accurate_rnd+full_chroma_int', '-colorspace', '1', '-color_primaries', '1', '-color_trc', '1'

'-pix_fmt rgb24', means treat the image as RGB (or RGBA) 
'-sws_flags +accurate_rnd+full_chroma_int', means use full color and chroma subsampling instead of 4:2:0 
'-colorspace 1', '-color_primaries 1', '-color_trc 1' put the metadata color tags to the png